### PR TITLE
remove canCheckNextDigits function

### DIFF
--- a/src/main/kotlin/Palindromic.kt
+++ b/src/main/kotlin/Palindromic.kt
@@ -15,13 +15,8 @@ class Palindromic {
             if (!areDigitsEquals(value, start, end)) {
                 return false
             }
-            if (canCheckNextDigits(start, end)) {
-                return isPalindromic(value, start + 1, end - 1)
-            }
-            return true
+            return isPalindromic(value, start + 1, end - 1)
         }
-
-        private fun canCheckNextDigits(start: Int, end: Int) = (start + 1) < (end - 1)
 
         private fun areDigitsEquals(value: String, start: Int, end: Int) = value[start] == value[end]
 


### PR DESCRIPTION
## Why?
- We could remove the canCheckNextDigits function because we are only avoiding one iteration with it. The stop condition could be when the end > start.

## How
- Remove the function and run all the suite test.